### PR TITLE
[Feat] 로드밸런싱을 위한 AI Server 수정 (#11)

### DIFF
--- a/api/diagnosis/diagnosis_routes.py
+++ b/api/diagnosis/diagnosis_routes.py
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 router = APIRouter()
 logger = get_logger(__name__)
 
-@router.get("/diagnosis/drowiness")
+@router.get("/diagnosis/drowsiness")
 async def get_diagnosis_result(request: Request, device_uid: str = Query(..., alias="deviceUid")):
     model = request.app.state.model
 

--- a/api/diagnosis/diagnosis_routes.py
+++ b/api/diagnosis/diagnosis_routes.py
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 router = APIRouter()
 logger = get_logger(__name__)
 
-@router.get("/api/diagnosis/drowiness")
+@router.get("/diagnosis/drowiness")
 async def get_diagnosis_result(request: Request, device_uid: str = Query(..., alias="deviceUid")):
     model = request.app.state.model
 

--- a/api/frame/frame_routes.py
+++ b/api/frame/frame_routes.py
@@ -17,7 +17,7 @@ logger = get_logger(__name__)
 uid_queues: Dict[str, TimedQueue] = {}
 
 
-@router.post("/api/save/frame")
+@router.post("/save/frame")
 async def save_frame(data: FrameRequest):
     device_uid = data.deviceUid
     frame_idx = data.frameIdx

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 module_path = Path(__file__).parent
 sys.path.append(str(module_path))
 
+from typing import Dict, Any
 from fastapi import FastAPI, HTTPException
 from fastapi.exceptions import RequestValidationError
 from api.frame.frame_routes import router as frame_router
@@ -39,7 +40,7 @@ async def startup_event():
     app.state.model = await load_model_async()
 
 @app.get("/ai/health")
-def health_check():
+def health_check() -> Dict[str, Any]:
     model = getattr(app.state, "model", None)
     if model is None:
         raise HTTPException(status_code=500, detail="모델이 로드되지 않았습니다.")

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ module_path = Path(__file__).parent
 sys.path.append(str(module_path))
 
 from fastapi import FastAPI
+from fastapi import HTTPException
 from fastapi.exceptions import RequestValidationError
 from api.frame.frame_routes import router as frame_router
 from api.diagnosis.diagnosis_routes import router as diagnosis_router
@@ -37,6 +38,13 @@ async def load_model_async():
 @app.on_event("startup")
 async def startup_event():
     app.state.model = await load_model_async()
+
+@app.get("/ai/health")
+def health_check():
+    model = getattr(app.state, "model", None)
+    if model is None:
+        raise HTTPException(status_code=500, detail="모델이 로드되지 않았습니다.")
+    return {"status": "ok", "model_loaded": True}
 
 def main():
     import uvicorn

--- a/main.py
+++ b/main.py
@@ -21,8 +21,8 @@ logger = get_logger(__name__)
 app = FastAPI()
 app.add_middleware(BaseHTTPMiddleware, dispatch=log_request)
 
-app.include_router(frame_router, tags=["진단용 이미지 저장"])
-app.include_router(diagnosis_router, tags=["진단 결과 조회"])
+app.include_router(frame_router, prefix="/ai", tags=["진단용 이미지 저장"])
+app.include_router(diagnosis_router, prefix="/ai", tags=["진단 결과 조회"])
 
 app.add_exception_handler(RequestValidationError, validation_exception_handler)
 app.add_exception_handler(StarletteHTTPException, http_exception_handler)

--- a/main.py
+++ b/main.py
@@ -5,8 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 module_path = Path(__file__).parent
 sys.path.append(str(module_path))
 
-from fastapi import FastAPI
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
 from fastapi.exceptions import RequestValidationError
 from api.frame.frame_routes import router as frame_router
 from api.diagnosis.diagnosis_routes import router as diagnosis_router

--- a/tests/test_frame_routes.py
+++ b/tests/test_frame_routes.py
@@ -21,7 +21,7 @@ async def test_save_frame_success_and_check_queue(): # 200 테스트
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        response = await ac.post("/api/save/frame", json=payload)
+        response = await ac.post("/ai/save/frame", json=payload)
 
     assert response.status_code == 200
     assert response.json()["success"] is True
@@ -40,7 +40,7 @@ async def test_invalid_base64_raises_custom_error(): # base64가 아닐 경우 �
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        response = await ac.post("/api/save/frame", json=payload)
+        response = await ac.post("/ai/save/frame", json=payload)
 
     assert response.status_code == 422
     json_resp = response.json()
@@ -60,7 +60,7 @@ async def test_invalid_image_raises_custom_error(): # 유효한 base64지만 이
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        response = await ac.post("/api/save/frame", json=payload)
+        response = await ac.post("/ai/save/frame", json=payload)
 
     assert response.status_code == 422
     json_resp = response.json()
@@ -87,7 +87,7 @@ async def test_queue_full_raises_custom_error(monkeypatch): # 강제로 큐를 �
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        resp = await ac.post("/api/save/frame", json=payload)
+        resp = await ac.post("/ai/save/frame", json=payload)
 
     json_resp = resp.json()
     assert resp.status_code == 429


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 연결해 주세요.  
> closed #11 

## 📝 작업 내용

> 이번 PR에서 어떤 작업을 했는지 간단히 작성해 주세요.

- 백엔드 서버가 /api로 ai 서버와 동일한 prefix를 사용하고 있어 구별이 어려운 문제 때문에 ai server 엔드포인트 prefix를 /ai로 변경
- 주기적으로 AWS 로드밸런싱에서 요청하는 url 200ok 확인을 위한 추가 health-check GET api 구현 

### 📸 스크린샷 (선택)

> UI 변경사항이 있다면 캡처해서 첨부해 주세요.

## 💬 리뷰 요청사항 (선택)

> 리뷰어가 중점적으로 봐줬으면 하는 부분이 있다면 적어 주세요.  
> 예: `메서드 XXX의 네이밍`을 좀 더 의미 있게 바꾸고 싶은데 좋은 아이디어가 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 서비스 상태와 모델 로딩 여부를 확인할 수 있는 건강 상태 확인(health check) 엔드포인트(`/ai/health`)가 추가되었습니다.

- **Refactor**
  - 기존 엔드포인트의 URL 경로에서 `/api` 접두사가 제거되고, `/ai` 접두사가 추가되어 접근 경로가 변경되었습니다.  
    (예: `/api/diagnosis/drowiness` → `/ai/diagnosis/drowsiness`, `/api/save/frame` → `/ai/save/frame`)  
  - 오타가 있던 경로(`/drowiness`)가 올바르게 수정되었습니다(`/drowsiness`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->