### PR TITLE
[Test] 모델 로드 모킹 및 결과 반환 API 테스트 완료 (#9)

### DIFF
--- a/tests/test_diagnosis_routes.py
+++ b/tests/test_diagnosis_routes.py
@@ -79,3 +79,22 @@ async def test_no_frames_in_queue():
 
     assert resp.status_code == 404
     assert resp.json()["error"]["message"] == "no_frames"
+
+@pytest.mark.asyncio
+async def test_insufficient_frames():
+    device_uid = "uid_insufficient"
+    queue = TimedQueue(maxsize=48, window_seconds=2)
+
+    for i in range(10):  # 10 < 43
+        img = Image.new("RGB", (145, 145), color="green")
+        await queue.put((i, img))
+    uid_queues[device_uid] = queue
+
+    app.state.model = MagicMock()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/ai/diagnosis/drowsiness", params={"deviceUid": device_uid})
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["message"] == "insufficient_frames"

--- a/tests/test_diagnosis_routes.py
+++ b/tests/test_diagnosis_routes.py
@@ -13,7 +13,7 @@ from PIL import Image
 
 
 @pytest.mark.asyncio
-async def test_get_diagnosis_success(monkeypatch):
+async def test_get_diagnosis_success():
     device_uid = "uid_success"
     queue = TimedQueue(maxsize=48, window_seconds=2)
 
@@ -36,3 +36,16 @@ async def test_get_diagnosis_success(monkeypatch):
     assert data["success"] is True
     assert data["isDrowsinessDrive"] is True # 0.5 이하는 True 반환
     assert "detectionTime" in data
+
+@pytest.mark.asyncio
+async def test_model_not_loaded():
+    app.state.model = None
+    device_uid = "uid_any"
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/ai/diagnosis/drowsiness", params={"deviceUid": device_uid})
+
+    assert resp.status_code == 500
+    data = resp.json()
+    assert data["error"]["message"] == "model_not_loaded"

--- a/tests/test_diagnosis_routes.py
+++ b/tests/test_diagnosis_routes.py
@@ -120,7 +120,7 @@ async def test_preprocessing_error():
     assert resp.json()["error"]["message"] == "invalid_data"
 
 @pytest.mark.asyncio
-async def test_prediction_error():
+async def test_prediction_error(monkeypatch):
     device_uid = "uid_predict_error"
     queue = TimedQueue(maxsize=48, window_seconds=2)
 
@@ -131,7 +131,8 @@ async def test_prediction_error():
 
     mock_model = MagicMock()
     mock_model.predict.side_effect = Exception("예측 실패 발생")
-    app.state.model = mock_model
+
+    monkeypatch.setattr(app.state, "model", mock_model)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
@@ -139,4 +140,3 @@ async def test_prediction_error():
 
     assert resp.status_code == 500
     assert resp.json()["error"]["message"] == "prediction_error"
-

--- a/tests/test_diagnosis_routes.py
+++ b/tests/test_diagnosis_routes.py
@@ -64,3 +64,18 @@ async def test_queue_not_found():
 
     assert resp.status_code == 404
     assert resp.json()["error"]["message"] == "queue_not_found"
+
+@pytest.mark.asyncio
+async def test_no_frames_in_queue():
+    device_uid = "uid_empty"
+    queue = TimedQueue(maxsize=48, window_seconds=2)
+    uid_queues[device_uid] = queue
+
+    app.state.model = MagicMock()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/ai/diagnosis/drowsiness", params={"deviceUid": device_uid})
+
+    assert resp.status_code == 404
+    assert resp.json()["error"]["message"] == "no_frames"

--- a/tests/test_diagnosis_routes.py
+++ b/tests/test_diagnosis_routes.py
@@ -98,3 +98,24 @@ async def test_insufficient_frames():
 
     assert resp.status_code == 400
     assert resp.json()["error"]["message"] == "insufficient_frames"
+
+@pytest.mark.asyncio
+async def test_preprocessing_error():
+    device_uid = "uid_preproc_error"
+    queue = TimedQueue(maxsize=48, window_seconds=2)
+
+    # 넣는 프레임을 numpy 배열로 변환할 수 없는 타입으로 지정
+    # preprocess_input_data 함수 테스트
+    for i in range(48):
+        await queue.put((i, "not-an-image-object"))
+    uid_queues[device_uid] = queue
+
+    app.state.model = MagicMock()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/ai/diagnosis/drowsiness", params={"deviceUid": device_uid})
+
+    assert resp.status_code == 422
+    assert resp.json()["error"]["message"] == "invalid_data"
+

--- a/tests/test_diagnosis_routes.py
+++ b/tests/test_diagnosis_routes.py
@@ -49,3 +49,18 @@ async def test_model_not_loaded():
     assert resp.status_code == 500
     data = resp.json()
     assert data["error"]["message"] == "model_not_loaded"
+
+@pytest.mark.asyncio
+async def test_queue_not_found():
+    app.state.model = MagicMock()
+    device_uid = "nonexistent_uid"
+
+    if device_uid in uid_queues:
+        del uid_queues[device_uid]
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/ai/diagnosis/drowsiness", params={"deviceUid": device_uid})
+
+    assert resp.status_code == 404
+    assert resp.json()["error"]["message"] == "queue_not_found"

--- a/tests/test_diagnosis_routes.py
+++ b/tests/test_diagnosis_routes.py
@@ -1,0 +1,38 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from unittest.mock import AsyncMock, MagicMock
+from main import app
+from api.frame.frame_routes import uid_queues
+from api.frame.TimedQueue import TimedQueue
+import numpy as np
+from PIL import Image
+
+
+@pytest.mark.asyncio
+async def test_get_diagnosis_success(monkeypatch):
+    device_uid = "uid_success"
+    queue = TimedQueue(maxsize=48, window_seconds=2)
+
+    for i in range(48):
+        img = Image.new("RGB", (145, 145), color="blue") # 임의 이미지 데이터 세팅
+        await queue.put((i, img))
+    uid_queues[device_uid] = queue
+
+    mock_model = MagicMock()
+    mock_model.predict.return_value = np.array([[0.3]])
+
+    app.state.model = mock_model
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/ai/diagnosis/drowsiness", params={"deviceUid": device_uid})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    assert data["isDrowsinessDrive"] is True # 0.5 이하는 True 반환
+    assert "detectionTime" in data

--- a/tests/test_diagnosis_routes.py
+++ b/tests/test_diagnosis_routes.py
@@ -119,3 +119,24 @@ async def test_preprocessing_error():
     assert resp.status_code == 422
     assert resp.json()["error"]["message"] == "invalid_data"
 
+@pytest.mark.asyncio
+async def test_prediction_error():
+    device_uid = "uid_predict_error"
+    queue = TimedQueue(maxsize=48, window_seconds=2)
+
+    for i in range(48):
+        img = Image.new("RGB", (145, 145), color="black")
+        await queue.put((i, img))
+    uid_queues[device_uid] = queue
+
+    mock_model = MagicMock()
+    mock_model.predict.side_effect = Exception("예측 실패 발생")
+    app.state.model = mock_model
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/ai/diagnosis/drowsiness", params={"deviceUid": device_uid})
+
+    assert resp.status_code == 500
+    assert resp.json()["error"]["message"] == "prediction_error"
+


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 연결해 주세요.  
> closed #9 

## 📝 작업 내용

> 이번 PR에서 어떤 작업을 했는지 간단히 작성해 주세요.

- 모델 모킹
- 모델 결과 반환 200 테스트 
- get_frames_from_queue 메소드 모든 예외 상황 테스트
- preprocess_input_data 메소드 모든 예외 상황 테스트
- 모델 예측 Exception 시 테스트

### 📸 스크린샷 (선택)

> UI 변경사항이 있다면 캡처해서 첨부해 주세요.

## 💬 리뷰 요청사항 (선택)

> 리뷰어가 중점적으로 봐줬으면 하는 부분이 있다면 적어 주세요.  
> 예: `메서드 XXX의 네이밍`을 좀 더 의미 있게 바꾸고 싶은데 좋은 아이디어가 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
  - AI 졸음 진단 엔드포인트(`/ai/diagnosis/drowsiness`)에 대한 다양한 상황의 비동기 테스트 케이스가 추가되었습니다.
  - 정상 요청, 모델 미적재, 프레임 큐 없음, 프레임 부족, 전처리 오류, 예측 오류 등 다양한 에러 및 예외 상황에 대한 검증이 포함되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->