### PR TITLE
[Deploy] AWS EC2 AI Server 배포 자동화 파이프라인 구축 완료 (#10)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,8 @@ jobs:
         username: ${{ secrets.EC2_USER }}
         key: ${{ secrets.DEPLOY_SSH_KEY }}
         script: |
-          mkdir -p /home/noSleepDrive/app/ai
-          chown -R ${{ secrets.EC2_USER }}:${{ secrets.EC2_USER }} /home/noSleepDrive/app
+          sudo mkdir -p /home/noSleepDrive/app/ai
+          sudo chown -R ${{ secrets.EC2_USER }}:${{ secrets.EC2_USER }} /home/noSleepDrive/app
 
 
     - name: EC2에 소스 코드 업로드

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,45 +15,55 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v3
 
-    - name: SSH 설정
-      run: |
-        mkdir -p ~/.ssh
-        echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_rsa
-        chmod 600 ~/.ssh/id_rsa
-        ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts
+    - name: EC2에 AI Server 디렉터리 생성
+      uses: appleboy/ssh-action@v0.1.7
+      with:
+        host: ${{ secrets.EC2_HOST }}
+        username: ${{ secrets.EC2_USER }}
+        key: ${{ secrets.DEPLOY_SSH_KEY }}
+        script: |
+          mkdir -p /home/noSleepDrive/app/ai
+          chown -R ${{ secrets.EC2_USER }}:${{ secrets.EC2_USER }} /home/noSleepDrive/app
 
-    - name: EC2 배포 환경 python 세팅
-      run: |
-        ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
+
+    - name: EC2에 소스 코드 업로드
+      uses: appleboy/scp-action@v0.1.4
+      with:
+        host: ${{ secrets.EC2_HOST }}
+        username: ${{ secrets.EC2_USER }}
+        key: ${{ secrets.DEPLOY_SSH_KEY }}
+        source: "."
+        target: "/home/noSleepDrive/app/ai"
+
+    - name: EC2 배포 환경 python 가상 환경 세팅
+      uses: appleboy/ssh-action@v0.1.7
+      with:
+        host: ${{ secrets.EC2_HOST }}
+        username: ${{ secrets.EC2_USER }}
+        key: ${{ secrets.DEPLOY_SSH_KEY }}
+        script: |
           set -e
           sudo apt update
           sudo apt install -y python3 python3-venv python3-pip
           mkdir -p /home/noSleepDrive
-        EOF
-
-    - name: 소스 코드 업로드
-      run: |
-        scp -o StrictHostKeyChecking=no -r . ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/noSleepDrive
-
-    - name: 가상환경 세팅 및 필요한 라이브러리 requirements 설치
-      run: |
-        ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
           cd /home/noSleepDrive
           python3 -m venv .venv
           source .venv/bin/activate
           pip install --upgrade pip
-          if [ -f "requirements.txt" ]; then
+          if [ -f "app/ai/requirements.txt" ]; then
             pip install -r app/ai/requirements.txt
           else
             pip install fastapi uvicorn
           fi
-        EOF
 
     - name: systemd service Reload && enable 및 FastAPI 재시작
-      run: |
-        ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
+      uses: appleboy/ssh-action@v0.1.7
+      with:
+        host: ${{ secrets.EC2_HOST }}
+        username: ${{ secrets.EC2_USER }}
+        key: ${{ secrets.DEPLOY_SSH_KEY }}
+        script: |
           sudo systemctl daemon-reload
           sudo systemctl enable fastapi.service
           sudo systemctl restart fastapi.service
-        EOF
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy FastAPI Server to EC2
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v3
+
+    - name: SSH 설정
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+        ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts
+
+    - name: EC2 배포 환경 python 세팅
+      run: |
+        ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
+          set -e
+          sudo apt update
+          sudo apt install -y python3 python3-venv python3-pip
+          mkdir -p ~/noSleepDrive
+        EOF
+
+    - name: 소스 코드 업로드
+      run: |
+        scp -o StrictHostKeyChecking=no -r . ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/noSleepDrive
+
+    - name: 가상환경 세팅 및 필요한 라이브러리 requirements 설치
+      run: |
+        ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
+          cd ~/noSleepDrive
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install --upgrade pip
+          if [ -f "requirements.txt" ]; then
+            pip install -r requirements.txt
+          else
+            pip install fastapi uvicorn
+          fi
+        EOF
+
+    - name: systemd service Reload && enable 및 FastAPI 재시작
+      run: |
+        ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
+          sudo systemctl daemon-reload
+          sudo systemctl enable fastapi.service
+          sudo systemctl restart fastapi.service
+        EOF
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,10 +2,13 @@ name: Deploy FastAPI Server to EC2
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - deploy/#10
 
 jobs:
   deploy:
+    environment: prod
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy FastAPI Server to EC2
+name: Deploy FastAPI AI Server to EC2
 
 on:
   push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - deploy/#10
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,22 +28,22 @@ jobs:
           set -e
           sudo apt update
           sudo apt install -y python3 python3-venv python3-pip
-          mkdir -p ~/noSleepDrive
+          mkdir -p /home/noSleepDrive
         EOF
 
     - name: 소스 코드 업로드
       run: |
-        scp -o StrictHostKeyChecking=no -r . ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/noSleepDrive
+        scp -o StrictHostKeyChecking=no -r . ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/noSleepDrive
 
     - name: 가상환경 세팅 및 필요한 라이브러리 requirements 설치
       run: |
         ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
-          cd ~/noSleepDrive
+          cd /home/noSleepDrive
           python3 -m venv .venv
           source .venv/bin/activate
           pip install --upgrade pip
           if [ -f "requirements.txt" ]; then
-            pip install -r requirements.txt
+            pip install -r app/ai/requirements.txt
           else
             pip install fastapi uvicorn
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ venv.bak/
 # log
 ./log
 ./tests/log
+
+# ssh private key
+no-sleep-drive-server


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 연결해 주세요.  
> closed #10

## 📝 작업 내용

> 이번 PR에서 어떤 작업을 했는지 간단히 작성해 주세요.

```
사용자명@IP:/home/noSleepDrive/app$ ls
ai  backend  frontend
```

- 위와 같은 배포 공용 dir에 ai 배포 자동화
- EC2 systemctl 등록 및 EC2 재부팅 시 자동 실행되도록 설정
- 인바운드 규칙 8000 허용 이후 외부에서 요청 및 swagger 접속됨을 확인(이미 배포 된 상태)

### 📸 스크린샷 (선택)

> UI 변경사항이 있다면 캡처해서 첨부해 주세요.

## 💬 리뷰 요청사항 (선택)

> 리뷰어가 중점적으로 봐줬으면 하는 부분이 있다면 적어 주세요.  
> 예: `메서드 XXX의 네이밍`을 좀 더 의미 있게 바꾸고 싶은데 좋은 아이디어가 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - FastAPI AI 서버를 EC2에 자동 배포하는 GitHub Actions 워크플로우가 추가되었습니다.
  - SSH 개인 키 파일(`no-sleep-drive-server`)이 버전 관리에서 제외되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->